### PR TITLE
msm8916: Stop building unused camera test util

### DIFF
--- a/msm8916.mk
+++ b/msm8916.mk
@@ -109,10 +109,7 @@ PRODUCT_COPY_FILES += \
 
 # Camera
 PRODUCT_PACKAGES += \
-    mm-qcamera-app \
     camera.msm8916 \
-    libmmjpeg_interface \
-    libqomx_core \
     Snap
 
 # Charger


### PR DESCRIPTION
- We don't need mm-qcamera-app
- Remove the other two because they'll be built automatically.

Change-Id: I461a1d718f06ab005e646276739a233db6705ad9
